### PR TITLE
ZOOKEEPER-4468: Update documentation about BCFKS keystore/truststore format

### DIFF
--- a/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
+++ b/zookeeper-docs/src/main/resources/markdown/zookeeperAdmin.md
@@ -1654,7 +1654,7 @@ and [SASL authentication for ZooKeeper](https://cwiki.apache.org/confluence/disp
     **New in 3.5.5:**
     Specifies the file format of client and quorum keystores. Values: JKS, PEM, PKCS12 or null (detect by filename).
     Default: null.
-    **New in 3.6.3, 3.7.0:**
+    **New in 3.5.10, 3.6.3, 3.7.0:**
     The format BCFKS was added.
 
 * *ssl.trustStore.location* and *ssl.trustStore.password* and *ssl.quorum.trustStore.location* and *ssl.quorum.trustStore.password* :
@@ -1675,7 +1675,7 @@ and [SASL authentication for ZooKeeper](https://cwiki.apache.org/confluence/disp
     **New in 3.5.5:**
     Specifies the file format of client and quorum trustStores. Values: JKS, PEM, PKCS12 or null (detect by filename).
     Default: null.
-    **New in 3.6.3, 3.7.0:**
+    **New in 3.5.10, 3.6.3, 3.7.0:**
     The format BCFKS was added.
 
 * *ssl.protocol* and *ssl.quorum.protocol* :


### PR DESCRIPTION
The BCFKS keystore/truststore format support was backported to branch 3.5, I updated the documentation.

Author: Mate Szalay-Beko <mszalay@cloudera.com>

Reviewers: Norbert Kalmar <nkalmar@apache.org>, Andor Molnar <andor@apache.org>

Closes #1816 from symat/ZOOKEEPER-4468-doc-update
