### PR TITLE
Fix typo in ZooKeeper Server Pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1093,7 +1093,7 @@
                     <exclude>commons-lang:commons-lang</exclude>
                   </excludes>
                   <searchTransitive>false</searchTransitive>
-                  <message>We don't use commons-lang any more, so do not depend on it directly.</message>
+                  <message>We don't use commons-lang anymore, so do not depend on it directly.</message>
                 </bannedDependencies>
               </rules>
             </configuration>
@@ -1127,7 +1127,7 @@
                     <exclude>com.googlecode.json-simple:json-simple</exclude>
                   </excludes>
                   <searchTransitive>false</searchTransitive>
-                  <message>We don't use json-simple any more, so do not depend on it directly.</message>
+                  <message>We don't use json-simple anymore, so do not depend on it directly.</message>
                 </bannedDependencies>
               </rules>
             </configuration>

--- a/zookeeper-server/pom.xml
+++ b/zookeeper-server/pom.xml
@@ -191,7 +191,7 @@
         <executions>
           <execution>
             <!-- ${maven.build.timestamp} does not support timezone :( -->
-            <id>tbuild-time</id>
+            <id>build-time</id>
             <goals>
               <goal>timestamp-property</goal>
             </goals>


### PR DESCRIPTION
I think that the id of this task should be `build-time`. And it has original be `build-time`.

Author: Shoothzj <shoothzj@gmail.com>

Reviewers: Enrico Olivelli <eolivelli@apache.org>, maoling <maoling@apache.org>

Closes #1781 from Shoothzj/fix-typo-in-zookeeper-server-pom
