### PR TITLE
ZOOKEEPER-4478: Suppress OWASP false positives zookeeper-jute-3.8.0-SNAPSHOT.jar: CVE-2021-29425, CVE-2021-28164, CVE-2021-34429

### DIFF
--- a/owaspSuppressions.xml
+++ b/owaspSuppressions.xml
@@ -53,4 +53,13 @@
            this writing  -->
       <cve>CVE-2019-3826</cve>
    </suppress>
+
+ 
+   <suppress>
+      <!-- Seems like false positives about zookeeper-jute -->
+      <cve>CVE-2021-29425</cve>
+      <cve>CVE-2021-28164</cve>
+      <cve>CVE-2021-34429</cve>
+   </suppress>
+
 </suppressions>


### PR DESCRIPTION
Author: Enrico Olivelli <eolivelli@apache.org>

Reviewers: Mate Szalay-Beko <symat@apache.org>

Closes #1824 from eolivelli/ZOOKEEPER-4478-owasp
