### PR TITLE
ZOOKEEPER-4480: Introduce end to end compatibility tests

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,74 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: End to End Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  compatibility:
+    strategy:
+      matrix:
+        jdk: [8, 11]
+        zk: [3.5.9, 3.6.3, 3.7.0, nightly]
+      fail-fast: false
+    timeout-minutes: 360
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK ${{ matrix.jdk }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.jdk }}
+      - name: Cache local maven repository
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2/repository/
+            !~/.m2/repository/org/apache/zookeeper
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Show the first log message
+        run: git log -n1
+      - name: Install C Dependencies
+        run: sudo apt-get install libcppunit-dev libsasl2-dev
+      - name: Build with Maven
+        run: mvn -B -V -e -ntp "-Dstyle.color=always" package -DskipTests
+        env:
+          MAVEN_OPTS: -Djansi.force=true
+      - name: Download ZooKeeper ${{ matrix.zk }}
+        if: matrix.zk != 'nightly'
+        run: |
+          curl -O https://archive.apache.org/dist/zookeeper/zookeeper-${{ matrix.zk }}/apache-zookeeper-${{ matrix.zk }}-bin.tar.gz
+          tar -xzvf apache-zookeeper-${{ matrix.zk }}-bin.tar.gz
+      - name: Test ZooKeeper nightly server and ${{ matrix.zk }} client
+        if: matrix.zk != 'nightly'
+        run: tools/ci/test-connectivity.py --server . --client apache-zookeeper-${{ matrix.zk }}-bin
+        env:
+          ZOOCFG: zoo_sample.cfg
+      - name: Test ZooKeeper ${{ matrix.zk }} server and nightly client
+        if: matrix.zk != 'nightly'
+        run: tools/ci/test-connectivity.py --server apache-zookeeper-${{ matrix.zk }}-bin --client .
+        env:
+          ZOOCFG: zoo_sample.cfg
+      - name: Test ZooKeeper nightly server and client
+        if: matrix.zk == 'nightly'
+        run: tools/ci/test-connectivity.py --server . --client .
+        env:
+          ZOOCFG: zoo_sample.cfg

--- a/tools/ci/test-connectivity.py
+++ b/tools/ci/test-connectivity.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import subprocess
+
+from pathlib import Path
+
+class Server():
+    def __init__(self, binpath):
+        self.binpath = binpath
+    def __enter__(self):
+        subprocess.run([f'{self.binpath}', 'start'], check=True)
+        return self
+    def __exit__(self, type, value, traceback):
+        subprocess.run([f'{self.binpath}', 'stop'], check=True)
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--server', help="basepath to zk server", required=True)
+    parser.add_argument('--client', help="basepath to zk client", required=True)
+
+    args = parser.parse_args()
+    
+    server_basepath = Path(args.server).absolute()
+    server_binpath = server_basepath / "bin" / "zkServer.sh"
+    assert server_binpath.exists(), f"server binpath not exist: {server_binpath}"
+    client_basepath = Path(args.client).absolute()
+    client_binpath = client_basepath / "bin" / "zkCli.sh"
+    assert client_binpath.exists(), f"client binpath not exist: {client_binpath}"
+
+    with Server(server_binpath):
+        subprocess.run([f'{client_binpath}', 'sync', '/'], check=True)


### PR DESCRIPTION
So far, I add a simplest test executing `bin/zkCli.sh sync /` for testing connectivity.

You can comment to enrich the test script.

This command itself is enough for proceeding the original proposal that merge `readOnly` field into `ConnectRequest` and `ConnectResponse` as it's tested with any successfully setup connection.

Author: tison <wander4096@gmail.com>

Reviewers: Enrico Olivelli <eolivelli@apache.org>, Mate Szalay-Beko <symat@apache.org>

Closes #1826 from tisonkun/e2e
