### PR TITLE
ZOOKEEPER-4519: Add closeSocket method to Testable interface

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/Testable.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/Testable.java
@@ -18,6 +18,8 @@
 
 package org.apache.zookeeper;
 
+import java.io.IOException;
+
 /**
  * Abstraction that exposes various methods useful for testing ZooKeeper
  */
@@ -34,5 +36,10 @@ public interface Testable {
      * @param event event to insert
      */
     void queueEvent(WatchedEvent event);
+
+    /**
+     * Close the ClientCnxn socket for testing purposes
+     */
+    default void closeSocket() throws IOException { }
 
 }

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeperTestable.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/ZooKeeperTestable.java
@@ -18,6 +18,7 @@
 
 package org.apache.zookeeper;
 
+import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,6 +46,12 @@ class ZooKeeperTestable implements Testable {
     public void queueEvent(WatchedEvent event) {
         LOG.info("queueEvent() called: {}", event);
         clientCnxn.eventThread.queueEvent(event);
+    }
+
+    @Override
+    public void closeSocket() throws IOException {
+        LOG.info("closeSocket() called");
+        clientCnxn.sendThread.testableCloseSocket();
     }
 
 }


### PR DESCRIPTION
This is backwards compatible, since the new method on the `Testable` interface defaults to a no-op.

Author: Houston Putman <houston@apache.org>

Reviewers: Enrico Olivelli <eolivelli@apache.org>, maoling <maoling@apache.org>

Closes #1863 from HoustonPutman/zk-testable-socket-close and squashes the following commits:

1f9d814f5 [Houston Putman] Fix style
475c9f516 [Houston Putman] ZOOKEEPER-4519: Add closeSocket method to Testable interface
