### PR TITLE
ZOOKEEPER-4551: Do not log spammy stacktrace when a client closes its connection

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/NIOServerCnxn.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/NIOServerCnxn.java
@@ -330,7 +330,15 @@ public class NIOServerCnxn extends ServerCnxn {
             if (k.isReadable()) {
                 int rc = sock.read(incomingBuffer);
                 if (rc < 0) {
-                    handleFailedRead();
+                    try {
+                        handleFailedRead();
+                    } catch (EndOfStreamException e) {
+                        // no stacktrace. this case is very common, and it is usually not a problem.
+                        LOG.info("{}", e.getMessage());
+                        // expecting close to log session closure
+                        close(e.getReason());
+                        return;
+                    }
                 }
                 if (incomingBuffer.remaining() == 0) {
                     boolean isPayload;


### PR DESCRIPTION
Motivation:
See more here https://issues.apache.org/jira/browse/ZOOKEEPER-4551

Modifications:
Do not log the stacktrace, just write the message at INFO level

Author: Enrico Olivelli <eolivelli@apache.org>

Reviewers: Mate Szalay-Beko <symat@apache.org>

Closes #1889 from eolivelli/fix/remove-spam-stacktrace
