### PR TITLE
ZOOKEEPER-4518: remove useless log in the PrepRequestProcessor#pRequest method

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/PrepRequestProcessor.java
@@ -770,8 +770,6 @@ public class PrepRequestProcessor extends ZooKeeperCriticalThread implements Req
      * @param request
      */
     protected void pRequest(Request request) throws RequestProcessorException {
-        // LOG.info("Prep>>> cxid = " + request.cxid + " type = " +
-        // request.type + " id = 0x" + Long.toHexString(request.sessionId));
         request.setHdr(null);
         request.setTxn(null);
 


### PR DESCRIPTION
ZOOKEEPER-4518 : remove useless log in the PrepRequestProcessor#pRequest method

Author: vinayvinayu <vinayvinayu@gmail.com>

Reviewers: Enrico Olivelli <eolivelli@apache.org>, maoling <maoling@apache.org>

Closes #1862 from Vinayvinayu/ZOOKEEPER-4518
