### PR TITLE
ZOOKEEPER-3860: Avoid reverse DNS lookup for hostname verification when hostnames are provided in the connection url

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/common/NetUtils.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/common/NetUtils.java
@@ -27,17 +27,18 @@ import java.net.InetSocketAddress;
  */
 public class NetUtils {
 
+    /**
+     * Prefer using the hostname for formatting, but without requesting reverse DNS lookup.
+     * Fall back to IP address if hostname is unavailable and use [] brackets for IPv6 literal.
+     */
     public static String formatInetAddr(InetSocketAddress addr) {
+        String hostString = addr.getHostString();
         InetAddress ia = addr.getAddress();
 
-        if (ia == null) {
-            return String.format("%s:%s", addr.getHostString(), addr.getPort());
-        }
-
-        if (ia instanceof Inet6Address) {
-            return String.format("[%s]:%s", ia.getHostAddress(), addr.getPort());
+        if (ia instanceof Inet6Address && hostString.contains(":")) {
+            return String.format("[%s]:%s", hostString, addr.getPort());
         } else {
-            return String.format("%s:%s", ia.getHostAddress(), addr.getPort());
+            return String.format("%s:%s", hostString, addr.getPort());
         }
     }
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/common/NetUtilsTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/common/NetUtilsTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.zookeeper.common;
 
-import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -40,7 +39,7 @@ public class NetUtilsTest extends ZKTestCase {
     @Test
     public void testFormatInetAddrGoodIpv4() {
         InetSocketAddress isa = new InetSocketAddress(v4addr, port);
-        assertEquals("127.0.0.1:1234", NetUtils.formatInetAddr(isa));
+        assertEquals(v4local, NetUtils.formatInetAddr(isa));
     }
 
     @Test
@@ -60,8 +59,7 @@ public class NetUtilsTest extends ZKTestCase {
     @Test
     public void testFormatInetAddrGoodHostname() {
         InetSocketAddress isa = new InetSocketAddress("localhost", 1234);
-
-        assertThat(NetUtils.formatInetAddr(isa), anyOf(equalTo(v4local), equalTo(v6local)));
+        assertThat(NetUtils.formatInetAddr(isa), equalTo("localhost:1234"));
     }
 
     @Test


### PR DESCRIPTION
Instead of altering the behaviour of `ZKTrustManager`, I'll add the following improvements:

1. `NetUtils.formatInetAddr()` should prefer using the hostname of resolved addresses when converting InetSocketAddress to String. Previously it only picked the hostname if address was missing, e.g. the hostname was unresolved. This change has the advantage of sending the hostname in the InitialMessage instead of the IP address, which will help avoiding unnecessary reverse DNS lookups in the election protocol when TLS is enabled.

2. Add extra debug logs to `ZKTrustManager` and remove logging the exception stack trace when IP verification failed. Logging of stack traces makes sense to me in error log entries only. Many times we hit into this when user turns on debug logging, seeing a big stack trace and believes it's an error in ZooKeeper.

Target branches: master, branch-3.8

Author: Andor Molnar <andor@cloudera.com>

Reviewers: eolivelli@apache.org

Closes #2005 from anmolnar/ZOOKEEPER-3860
