### PR TITLE
ZOOKEEPER-4026: Support `OpCode.create2` in `OpCode.multi`

### DIFF
--- a/zookeeper-server/src/main/java/org/apache/zookeeper/CreateOptions.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/CreateOptions.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zookeeper;
+
+import java.util.List;
+import java.util.Objects;
+import org.apache.zookeeper.data.ACL;
+import org.apache.zookeeper.server.EphemeralType;
+
+/**
+ * Options for creating znode in ZooKeeper data tree.
+ */
+public class CreateOptions {
+    private final CreateMode createMode;
+    private final List<ACL> acl;
+    private final long ttl;
+
+    public CreateMode getCreateMode() {
+        return createMode;
+    }
+
+    public List<ACL> getAcl() {
+        return acl;
+    }
+
+    public long getTtl() {
+        return ttl;
+    }
+
+    /**
+     * Constructs a builder for {@link CreateOptions}.
+     *
+     * @param acl
+     *                the acl for the node
+     * @param createMode
+     *                specifying whether the node to be created is ephemeral
+     *                and/or sequential
+     */
+    public static Builder newBuilder(List<ACL> acl, CreateMode createMode) {
+        return new Builder(createMode, acl);
+    }
+
+    private CreateOptions(CreateMode createMode, List<ACL> acl, long ttl) {
+        this.createMode = createMode;
+        this.acl = acl;
+        this.ttl = ttl;
+        EphemeralType.validateTTL(createMode, ttl);
+    }
+
+    /**
+     * Builder for {@link CreateOptions}.
+     */
+    public static class Builder {
+        private final CreateMode createMode;
+        private final List<ACL> acl;
+        private long ttl = -1;
+
+        private Builder(CreateMode createMode, List<ACL> acl) {
+            this.createMode = Objects.requireNonNull(createMode, "create mode is mandatory for create options");
+            this.acl = Objects.requireNonNull(acl, "acl is mandatory for create options");
+        }
+
+        public Builder withTtl(long ttl) {
+            this.ttl = ttl;
+            return this;
+        }
+
+        public CreateOptions build() {
+            return new CreateOptions(createMode, acl, ttl);
+        }
+    }
+}

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/MultiOperationRecord.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/MultiOperationRecord.java
@@ -126,7 +126,12 @@ public class MultiOperationRecord implements Record, Iterable<Op> {
                 case ZooDefs.OpCode.createContainer:
                     CreateRequest cr = new CreateRequest();
                     cr.deserialize(archive, tag);
-                    add(Op.create(cr.getPath(), cr.getData(), cr.getAcl(), cr.getFlags()));
+                    CreateMode createMode = CreateMode.fromFlag(cr.getFlags(), null);
+                    if (createMode == null) {
+                        throw new IOException("invalid flag " + cr.getFlags() + " for create mode");
+                    }
+                    CreateOptions options = CreateOptions.newBuilder(cr.getAcl(), createMode).build();
+                    add(Op.create(cr.getPath(), cr.getData(), options, h.getType()));
                     break;
                 case ZooDefs.OpCode.createTTL:
                     CreateTTLRequest crTtl = new CreateTTLRequest();

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/DataTree.java
@@ -973,6 +973,7 @@ public class DataTree {
                     Record record;
                     switch (subtxn.getType()) {
                     case OpCode.create:
+                    case OpCode.create2:
                         record = new CreateTxn();
                         break;
                     case OpCode.createTTL:

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/MultiOperationRecordTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/MultiOperationRecordTest.java
@@ -33,7 +33,7 @@ public class MultiOperationRecordTest extends ZKTestCase {
     public void testRoundTrip() throws IOException {
         MultiOperationRecord request = new MultiOperationRecord();
         request.add(Op.check("check", 1));
-        request.add(Op.create("create", "create data".getBytes(), ZooDefs.Ids.CREATOR_ALL_ACL, ZooDefs.Perms.ALL));
+        request.add(Op.create("create", "create data".getBytes(), ZooDefs.Ids.CREATOR_ALL_ACL, CreateMode.EPHEMERAL.toFlag()));
         request.add(Op.delete("delete", 17));
         request.add(Op.setData("setData", "set data".getBytes(), 19));
 

--- a/zookeeper-server/src/test/java/org/apache/zookeeper/test/MultiOperationTest.java
+++ b/zookeeper-server/src/test/java/org/apache/zookeeper/test/MultiOperationTest.java
@@ -21,6 +21,7 @@ package org.apache.zookeeper.test;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -40,6 +41,7 @@ import org.apache.zookeeper.AsyncCallback;
 import org.apache.zookeeper.AsyncCallback.MultiCallback;
 import org.apache.zookeeper.ClientCnxn;
 import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.CreateOptions;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.Op;
 import org.apache.zookeeper.OpResult;
@@ -438,6 +440,28 @@ public class MultiOperationTest extends ClientBase {
                 Op.create("/multi1", new byte[0], Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT),
                 Op.create("/multi2", new byte[0], Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT)),
                 useAsync);
+        zk.getData("/multi0", false, null);
+        zk.getData("/multi1", false, null);
+        zk.getData("/multi2", false, null);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testCreate2(boolean useAsync) throws Exception {
+        CreateOptions options = CreateOptions.newBuilder(Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT).build();
+        List<Op> ops = Arrays.asList(
+            Op.create("/multi0", new byte[0], options),
+            Op.create("/multi1", new byte[0], options),
+            Op.create("/multi2", new byte[0], options));
+        List<OpResult> results = multi(zk, ops, useAsync);
+        for (int i = 0; i < ops.size(); i++) {
+            CreateResult createResult = (CreateResult) results.get(i);
+            assertEquals(ops.get(i).getPath(), createResult.getPath());
+            assertEquals(ZooDefs.OpCode.create2, createResult.getType(), createResult.getPath());
+            assertNotNull(createResult.getStat(), createResult.getPath());
+            assertNotEquals(0, createResult.getStat().getCzxid(), createResult.getPath());
+        }
+
         zk.getData("/multi0", false, null);
         zk.getData("/multi1", false, null);
         zk.getData("/multi2", false, null);


### PR DESCRIPTION
Currently, nesting `OpCode.create2` in `OpCode.multi` will not get `stat`(ZOOKEEPER-1297). The cause is multifold:
* `MultiOperationRecord.deserialize` decays `OpCode.create2` to  `OpCode.create`.
* `DataTree.processTxn` ignores `OpCode.create2`.

This commit complements ZOOKEEPER-1297 to add `stat` for `OpCode.create2` in `OpCode.multi`.

It also adds `CreateOptions` to cover create mode, acl and ttl to avoid massive overloading methods.

Author: Kezhu Wang <kezhuw@gmail.com>

Reviewers: Enrico Olivelli <eolivelli@apache.org>, Damien Diederen <ddiederen@apache.org>

Closes #1978 from kezhuw/ZOOKEEPER-4667-nest-create2-in-multi
